### PR TITLE
Fixing tagmanigest-md5.txt generation

### DIFF
--- a/lib/Archive/BagIt.pm
+++ b/lib/Archive/BagIt.pm
@@ -227,7 +227,13 @@ sub _tagmanifest_md5 {
   find (
     sub {
       my $file = $File::Find::name;
-      if (-f $_ && $_=~m/^tagmanifest-.*\.txt/) {
+      if ($_=~m/^data$/) {
+        $File::Find::prune=1;
+      }
+      elsif ($_=~m/^tagmanifest-.*\.txt/) {
+        # Ignore, we can't take digest from ourselves
+      }
+      elsif ( -f $_ ) {
         open(DATA, "<$_") or die("Cannot read $_: $!");
         my $digest = Digest::MD5->new->addfile(*DATA)->hexdigest;
         close(DATA);
@@ -235,10 +241,6 @@ sub _tagmanifest_md5 {
         print($md5_fh "$digest  $filename\n");
  
       }
-      elsif($_=~m/\/data$/) {
-        $File::Find::prune=1;
-      }
-
   }, $bagit);
 
   close(MD5);


### PR DESCRIPTION
In 0.046 there is an issue with the generation of tagmanifest-md5.txt files using:

```
  use Archive::BagIt;
  my $bag = Archive::BagIt->make_bag('directory/bla');
```

This will create a tagmanifest-md5.txt with content:

```
  d41d8cd98f00b204e9800998ecf8427e  tagmanifest-md5.txt
```

Manifest files can't contain an entry about themselves, plus the bagit.txt, bag-info.txt and manifest-md5.txt are skipped.
