### PR TITLE
Added 'use warnings;' to Archive::Bagit::Fast

### DIFF
--- a/lib/Archive/BagIt/Fast.pm
+++ b/lib/Archive/BagIt/Fast.pm
@@ -1,6 +1,7 @@
 package Archive::BagIt::Fast;
 
 use strict;
+use warnings;
 use parent "Archive::BagIt";
 
 # VERSION


### PR DESCRIPTION
This mini-change is to add warnings to the A::B::Fast package. This the last of all your packages which did not have `use warnings`.

I found it in your cpants rating:
http://cpants.cpanauthors.org/dist/Archive-BagIt/errors
